### PR TITLE
Viewing Party Endpoints: Create a viewing party, Add User to Viewing Party, Get All Viewing Parties

### DIFF
--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::MoviesController < ApplicationController
     query = params[:query]
     if query.present?
       movies = MovieGateway.search(query)
-      render json: { data: movies}
+      render json: MovieSerializer.format_movies(movies)
     else
       render json: { error: 'Query parameter is required' }, status: :bad_request
     end

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -48,8 +48,12 @@ class Api::V1::ViewingPartiesController < ApplicationController
       
       #render success response
       render json: ViewingPartySerializer.format_viewing_party(new_viewing_party), status: :created
+
   rescue ActiveRecord::RecordInvalid => e 
-    render json: { status: "error", message: e.errors}, status: :unprocessable_entity
+    render json: { 
+      status: "error", 
+      message: e.record.errors.full_messages
+    }, status: :unprocessable_entity
  
       # render json: {
       #   data: {

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::ViewingPartiesController < ApplicationController
  
     render json: ViewingPartySerializer.format_viewing_party(new_viewing_party), status: :created
 
+
   rescue ActiveRecord::RecordInvalid => e 
     render json: { 
       status: "error", 

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -1,5 +1,13 @@
 class Api::V1::ViewingPartiesController < ApplicationController
 
+  
+  def index
+    # binding.pry
+    viewing_parties = ViewingParty.all
+    render json: ViewingPartySerializer.format_viewing_parties(viewing_parties), status: :ok
+  end
+
+  
   def create
     new_viewing_party = ViewingParty.create_with_invitees!(params)
  

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -1,52 +1,56 @@
 class Api::V1::ViewingPartiesController < ApplicationController
 
   def create
-    name = params[:name] 
-    start_time = params[:start_time] 
-    end_time = params[:end_time]
-    movie_id = params[:movie_id] 
-    movie_title = params[:movie_title] 
-    invitees = params[:invitees].map(&:to_i) || []
+    # name = params[:name] 
+    # start_time = params[:start_time] 
+    # end_time = params[:end_time]
+    # movie_id = params[:movie_id] 
+    # movie_title = params[:movie_title] 
+    new_viewing_party = ViewingParty.create_with_invitees!(params)
+
+    # invitees = params[:invitees].map(&:to_i) || []
 
 
     #validate required params    
-    if name.blank? 
-      return render json: { error: "Please provide a name for your viewing party" }, status: :unprocessable_entity
-    end
-    if movie_title.blank? || movie_id.blank?
-      return render json: { error: "Both movie_id and move_name must be provided" }, status: :unprocessable_entity
-    end
-    if start_time.blank? || end_time.blank? 
-      return render json: { error: "Both start_time and end_time must be provided" }, status: :unprocessable_entity
-    end
-    if invitees.blank?  
-      return render json: { error: "Please add invitees to your viewing party" }, status: :unprocessable_entity
-    end
+    # if name.blank? 
+    #   return render json: { error: "Please provide a name for your viewing party" }, status: :unprocessable_entity
+    # end
+    # if movie_title.blank? || movie_id.blank?
+    #   return render json: { error: "Both movie_id and move_name must be provided" }, status: :unprocessable_entity
+    # end
+    # if start_time.blank? || end_time.blank? 
+    #   return render json: { error: "Both start_time and end_time must be provided" }, status: :unprocessable_entity
+    # end
+    # if invitees.blank?  
+    #   return render json: { error: "Please add invitees to your viewing party" }, status: :unprocessable_entity
+    # end
 
     #find host user
-    host_id = invitees.first 
-    host = User.find_by(id: host_id)
-    return render json: { error: "Host user not found" }, status: :unprocessable_entity if host.nil?
+    # host_id = invitees.first 
+    # host = User.find_by(id: host_id)
+    # return render json: { error: "Host user not found" }, status: :unprocessable_entity if host.nil?
 
     #create a new viewing party
-    new_viewing_party = ViewingParty.create!(viewing_party_params)
+    # new_viewing_party = ViewingParty.create!(viewing_party_params)
 
-    #associate users with Viewing Party
-    if new_viewing_party.persisted?
-      invitees.each do |invitee_id|
-        invitee = User.find_by(id: invitee_id)
-        if invitee
-          UserViewingParty.create!(
-            viewing_party: new_viewing_party, 
-            user: invitee, 
-            is_host: invitee.id == host.id
-          )   
-        end        
-      end
+    # #associate users with Viewing Party
+    # if new_viewing_party.persisted?
+    #   invitees.each do |invitee_id|
+    #     invitee = User.find_by(id: invitee_id)
+    #     if invitee
+    #       UserViewingParty.create!(
+    #         viewing_party: new_viewing_party, 
+    #         user: invitee, 
+    #         is_host: invitee.id == host.id
+    #       )   
+    #     end        
+    #   end
       
       #render success response
       render json: ViewingPartySerializer.format_viewing_party(new_viewing_party), status: :created
-
+  rescue ActiveRecord::RecordInvalid => e 
+    render json: { status: "error", message: e.errors}, status: :unprocessable_entity
+ 
       # render json: {
       #   data: {
       #     id: new_viewing_party.id.to_s,
@@ -66,21 +70,18 @@ class Api::V1::ViewingPartiesController < ApplicationController
       #     }
       #   }
       # }, status: :created
-    else
-      Rails.logger.error("Viewing Party creation failed: #{new_viewing_party.errors.full_messages}")
-      render json: { errors: new_viewing_party.errors.full_messages }, status: :unprocessable_entity
-    end
+   
     # else
     #   render json: { errors: viewing_party.errors.full_messages }, status: :unprocessable_entity
     # end
   end
 
 
-  private
+  # private
 
-  def viewing_party_params
-    params.permit(:name, :start_time, :end_time, :movie_id, :movie_title)
-  end
+  # def viewing_party_params
+  #   params.permit(:name, :start_time, :end_time, :movie_id, :movie_title)
+  # end
 
 end
 

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -1,134 +1,17 @@
 class Api::V1::ViewingPartiesController < ApplicationController
 
   def create
-    # name = params[:name] 
-    # start_time = params[:start_time] 
-    # end_time = params[:end_time]
-    # movie_id = params[:movie_id] 
-    # movie_title = params[:movie_title] 
     new_viewing_party = ViewingParty.create_with_invitees!(params)
-
-    # invitees = params[:invitees].map(&:to_i) || []
-
-
-    #validate required params    
-    # if name.blank? 
-    #   return render json: { error: "Please provide a name for your viewing party" }, status: :unprocessable_entity
-    # end
-    # if movie_title.blank? || movie_id.blank?
-    #   return render json: { error: "Both movie_id and move_name must be provided" }, status: :unprocessable_entity
-    # end
-    # if start_time.blank? || end_time.blank? 
-    #   return render json: { error: "Both start_time and end_time must be provided" }, status: :unprocessable_entity
-    # end
-    # if invitees.blank?  
-    #   return render json: { error: "Please add invitees to your viewing party" }, status: :unprocessable_entity
-    # end
-
-    #find host user
-    # host_id = invitees.first 
-    # host = User.find_by(id: host_id)
-    # return render json: { error: "Host user not found" }, status: :unprocessable_entity if host.nil?
-
-    #create a new viewing party
-    # new_viewing_party = ViewingParty.create!(viewing_party_params)
-
-    # #associate users with Viewing Party
-    # if new_viewing_party.persisted?
-    #   invitees.each do |invitee_id|
-    #     invitee = User.find_by(id: invitee_id)
-    #     if invitee
-    #       UserViewingParty.create!(
-    #         viewing_party: new_viewing_party, 
-    #         user: invitee, 
-    #         is_host: invitee.id == host.id
-    #       )   
-    #     end        
-    #   end
-      
-      #render success response
-      render json: ViewingPartySerializer.format_viewing_party(new_viewing_party), status: :created
+ 
+    render json: ViewingPartySerializer.format_viewing_party(new_viewing_party), status: :created
 
   rescue ActiveRecord::RecordInvalid => e 
     render json: { 
       status: "error", 
       message: e.record.errors.full_messages
     }, status: :unprocessable_entity
- 
-      # render json: {
-      #   data: {
-      #     id: new_viewing_party.id.to_s,
-      #     type: "viewing_party",
-      #     attributes: {
-      #       name: new_viewing_party.name, 
-      #       start_time: new_viewing_party.start_time,
-      #       end_time: new_viewing_party.end_time,
-      #       movie_id: new_viewing_party.movie_id,
-      #       movie_title: new_viewing_party.movie_title,
-      #       invitees: User.where(id: invitees).map do |user| {
-      #         id: user.id,
-      #         name: user.name, 
-      #         username: user.username
-      #       }
-      #       end
-      #     }
-      #   }
-      # }, status: :created
-   
-    # else
-    #   render json: { errors: viewing_party.errors.full_messages }, status: :unprocessable_entity
-    # end
+
   end
 
-
-  # private
-
-  # def viewing_party_params
-  #   params.permit(:name, :start_time, :end_time, :movie_id, :movie_title)
-  # end
-
 end
-
  
-     # # host = User.find(params[user:id]
-    # # viewing_parties/user_id...
-
-    # #create viewing party
-    # viewing_party = ViewingParty.new(
-    #   name: name,
-    #   start_time: start_time, 
-    #   end_time: end_time, 
-    #   movie_id: movie_id,
-    #   movie_title: movie_title
-    # )
-
-  # def create 
-  #   merchant = Merchant.find(params[:merchant_id])
-  #   coupon = merchant.coupons.new(coupon_params)
-
-  #   if coupon.save
-  #     render json: CouponSerializer.new(coupon), status: :created
-  #   else
-  #     render json: { error: coupon.errors.full_messages.to_sentence }, status: :unprocessable_entity
-  #   end
-  # end
-
-  # def index
-  #   render json: ViewingPartySerializer.format_user_list(ViewingParty.all)
-  # end
-
-
-    #create nested route: /api/vi/users/1/viewing_parties
-    # user = User.find(params[:user_id]) 
-
-    # movie = MovieGateway.fetch_movie_details(params[:movies])
-
-
-    # user = User....?
-    # # In the Controller: Within the ⁠create method of your ⁠ViewingPartyController call a gateway method (e.g., ⁠fetch_movie_details) to retrieve movie data from an external API as part of the viewing party creation logic. see images_controller in set_list_api
-    # viewing_party = ViewingParty.new(viewing_party_params)
-    # if viewing_party.save
-    #   render json: ViewingPartySerializer.new(viewing_party), status: :created
-    # else
-    #   render json: ErrorSerializer.format_error(ErrorMessage.new(user.errors.full_messages.to_sentence, 400)), status: :bad_request
-    # end

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -5,14 +5,33 @@ class Api::V1::ViewingPartiesController < ApplicationController
  
     render json: ViewingPartySerializer.format_viewing_party(new_viewing_party), status: :created
 
-
-  rescue ActiveRecord::RecordInvalid => e 
-    render json: { 
-      status: "error", 
-      message: e.record.errors.full_messages
-    }, status: :unprocessable_entity
-
+    rescue ActiveRecord::RecordInvalid => e 
+      render json: { 
+        status: "error", 
+        message: e.record.errors.full_messages
+      }, status: :unprocessable_entity
   end
 
+  def add_user
+    viewing_party = ViewingParty.find(params[:id])
+
+    invitee_user_id = params.require(:invitees_user_id)
+
+    user = User.find_by(id: invitee_user_id)
+    unless user
+      return render js: {error: 'User not found'}, status: :not_found
+    end
+
+    user_viewing_party = UserViewingParty.new(user_id: invitee_user_id, viewing_party_id: viewing_party.id, is_host: false)
+
+    if user_viewing_party.save
+      render json: { message: 'User added successfully'}, status: :ok
+    else
+      render json: { error: 'Failed to add user'}, 
+      status: :unprocessable_entity
+    end
+  end
+
+
+
 end
- 

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -7,7 +7,6 @@ class Api::V1::ViewingPartiesController < ApplicationController
     movie_id = params[:movie_id] 
     movie_title = params[:movie_title] 
     invitees = params[:invitees].map(&:to_i) || []
-    host_id = invitees.first 
 
 
     #validate required params    
@@ -25,6 +24,7 @@ class Api::V1::ViewingPartiesController < ApplicationController
     end
 
     #find host user
+    host_id = invitees.first 
     host = User.find_by(id: host_id)
     return render json: { error: "Host user not found" }, status: :unprocessable_entity if host.nil?
 
@@ -45,27 +45,29 @@ class Api::V1::ViewingPartiesController < ApplicationController
       end
       
       #render success response
-      render json: {
-        data: {
-          id: new_viewing_party.id.to_s,
-          type: "viewing_party",
-          attributes: {
-            name: new_viewing_party.name, 
-            start_time: new_viewing_party.start_time,
-            end_time: new_viewing_party.end_time,
-            movie_id: new_viewing_party.movie_id,
-            movie_title: new_viewing_party.movie_title,
-            invitees: User.where(id: invitees).map do |user| {
-              id: user.id,
-              name: user.name, 
-              username: user.username
-            }
-            end
-          }
-        }
-      }, status: :created
+      render json: ViewingPartySerializer.format_viewing_party(new_viewing_party), status: :created
+
+      # render json: {
+      #   data: {
+      #     id: new_viewing_party.id.to_s,
+      #     type: "viewing_party",
+      #     attributes: {
+      #       name: new_viewing_party.name, 
+      #       start_time: new_viewing_party.start_time,
+      #       end_time: new_viewing_party.end_time,
+      #       movie_id: new_viewing_party.movie_id,
+      #       movie_title: new_viewing_party.movie_title,
+      #       invitees: User.where(id: invitees).map do |user| {
+      #         id: user.id,
+      #         name: user.name, 
+      #         username: user.username
+      #       }
+      #       end
+      #     }
+      #   }
+      # }, status: :created
     else
-      Rails.logger.error("❌ Viewing Party creation failed: #{new_viewing_party.errors.full_messages}")
+      Rails.logger.error("Viewing Party creation failed: #{new_viewing_party.errors.full_messages}")
       render json: { errors: new_viewing_party.errors.full_messages }, status: :unprocessable_entity
     end
     # else

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -1,0 +1,127 @@
+class Api::V1::ViewingPartiesController < ApplicationController
+
+  def create
+    name = params[:name] 
+    start_time = params[:start_time] 
+    end_time = params[:end_time]
+    movie_id = params[:movie_id] 
+    movie_title = params[:movie_title] 
+    invitees = params[:invitees].map(&:to_i) || []
+    host_id = invitees.first 
+
+
+    #validate required params    
+    if name.blank? 
+      return render json: { error: "Please provide a name for your viewing party" }, status: :unprocessable_entity
+    end
+    if movie_title.blank? || movie_id.blank?
+      return render json: { error: "Both movie_id and move_name must be provided" }, status: :unprocessable_entity
+    end
+    if start_time.blank? || end_time.blank? 
+      return render json: { error: "Both start_time and end_time must be provided" }, status: :unprocessable_entity
+    end
+    if invitees.blank?  
+      return render json: { error: "Please add invitees to your viewing party" }, status: :unprocessable_entity
+    end
+
+    #find host user
+    host = User.find_by(id: host_id)
+    return render json: { error: "Host user not found" }, status: :unprocessable_entity if host.nil?
+
+    #create a new viewing party
+    new_viewing_party = ViewingParty.create!(viewing_party_params)
+
+    #associate users with Viewing Party
+    if new_viewing_party.persisted?
+      invitees.each do |invitee_id|
+        invitee = User.find_by(id: invitee_id)
+        if invitee
+          UserViewingParty.create!(
+            viewing_party: new_viewing_party, 
+            user: invitee, 
+            is_host: invitee.id == host.id
+          )   
+        end        
+      end
+      
+      #render success response
+      render json: {
+        data: {
+          id: new_viewing_party.id.to_s,
+          type: "viewing_party",
+          attributes: {
+            name: new_viewing_party.name, 
+            start_time: new_viewing_party.start_time,
+            end_time: new_viewing_party.end_time,
+            movie_id: new_viewing_party.movie_id,
+            movie_title: new_viewing_party.movie_title,
+            invitees: User.where(id: invitees).map do |user| {
+              id: user.id,
+              name: user.name, 
+              username: user.username
+            }
+            end
+          }
+        }
+      }, status: :created
+    else
+      Rails.logger.error("❌ Viewing Party creation failed: #{new_viewing_party.errors.full_messages}")
+      render json: { errors: new_viewing_party.errors.full_messages }, status: :unprocessable_entity
+    end
+    # else
+    #   render json: { errors: viewing_party.errors.full_messages }, status: :unprocessable_entity
+    # end
+  end
+
+
+  private
+
+  def viewing_party_params
+    params.permit(:name, :start_time, :end_time, :movie_id, :movie_title)
+  end
+
+end
+
+ 
+     # # host = User.find(params[user:id]
+    # # viewing_parties/user_id...
+
+    # #create viewing party
+    # viewing_party = ViewingParty.new(
+    #   name: name,
+    #   start_time: start_time, 
+    #   end_time: end_time, 
+    #   movie_id: movie_id,
+    #   movie_title: movie_title
+    # )
+
+  # def create 
+  #   merchant = Merchant.find(params[:merchant_id])
+  #   coupon = merchant.coupons.new(coupon_params)
+
+  #   if coupon.save
+  #     render json: CouponSerializer.new(coupon), status: :created
+  #   else
+  #     render json: { error: coupon.errors.full_messages.to_sentence }, status: :unprocessable_entity
+  #   end
+  # end
+
+  # def index
+  #   render json: ViewingPartySerializer.format_user_list(ViewingParty.all)
+  # end
+
+
+    #create nested route: /api/vi/users/1/viewing_parties
+    # user = User.find(params[:user_id]) 
+
+    # movie = MovieGateway.fetch_movie_details(params[:movies])
+
+
+    # user = User....?
+    # # In the Controller: Within the ⁠create method of your ⁠ViewingPartyController call a gateway method (e.g., ⁠fetch_movie_details) to retrieve movie data from an external API as part of the viewing party creation logic. see images_controller in set_list_api
+    # viewing_party = ViewingParty.new(viewing_party_params)
+    # if viewing_party.save
+    #   render json: ViewingPartySerializer.new(viewing_party), status: :created
+    # else
+    #   render json: ErrorSerializer.format_error(ErrorMessage.new(user.errors.full_messages.to_sentence, 400)), status: :bad_request
+    # end

--- a/app/gateway/movie_gateway.rb
+++ b/app/gateway/movie_gateway.rb
@@ -3,8 +3,6 @@ class MovieGateway
     movies = connect_to_api("/3/movie/top_rated", { language:
      "en-US", page: 1 })[:results]
     movie_objects = movies.map { |movie| Movie.new(movie) }
-
-   
     #when you're trying to define attributes for an object that doesn't exist in your schema it MUST be defined as a PORO
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
-  has_many :viewing_parties, through: user_viewing_parties
-  
+  has_many :viewing_parties, through: :user_viewing_parties
+
   validates :name, presence: true
   validates :username, presence: true, uniqueness: true
   validates :password, presence: { require: true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :viewing_parties, through: user_viewing_parties
+  
   validates :name, presence: true
   validates :username, presence: true, uniqueness: true
   validates :password, presence: { require: true }

--- a/app/models/user_viewing_party.rb
+++ b/app/models/user_viewing_party.rb
@@ -1,0 +1,7 @@
+class UserViewingParty < ApplicationRecord
+  # validates :user, presence: true
+  # validates :viewing_party, presence: true 
+  belongs_to :user
+  belongs_to :viewing_party
+
+end

--- a/app/models/user_viewing_party.rb
+++ b/app/models/user_viewing_party.rb
@@ -3,5 +3,4 @@ class UserViewingParty < ApplicationRecord
   # validates :viewing_party, presence: true 
   belongs_to :user
   belongs_to :viewing_party
-
 end

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -1,5 +1,6 @@
 class ViewingParty < ApplicationRecord
   has_many :users, through: :user_viewing_parties
+  has_many :user_viewing_parties
 
   validates :name, presence: true
   validates :start_time, presence: true

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -19,14 +19,16 @@ class ViewingParty < ApplicationRecord
     viewing_party = ViewingParty.create!(permitted_params)
     puts "Viewing party created: #{viewing_party}"
 
+    # binding.pry
+
     host = find_and_validate_host!(invitees, viewing_party)
     puts "Host found: #{host}"
+   
     # raise ActiveRecord::RecordInvalid.new(self.new), "Host user not found" if host.nil 
-
     # UserViewingParty.create!(viewing_party: viewing_party, user: host, is_host: true)
-    
     # if new_viewing_party.persisted? #successfully saved? to prevent associating users w/ non-existent viewing parties
     # end
+
     puts "Invitees before association with VP: #{invitees}"
     associate_user_with_viewing_party(viewing_party, invitees, host)
     # host_id = host.id
@@ -40,7 +42,6 @@ class ViewingParty < ApplicationRecord
     puts "Viewing party : #{viewing_party}" 
 
     viewing_party
-
   end
 
   private

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -1,0 +1,18 @@
+class ViewingParty < ApplicationRecord
+  has_many :users, through: user_viewing_parties
+
+  validates :name, presence: true
+  validates :start_time, presence: true
+  validates :end_time, presence: true
+  validates :movie_id, presence: true
+  validates :movie_title, presence: true
+  validates :host_user_id, presence: true
+ 
+end
+
+
+has_many :enrollments
+has_many :courses, through: :enrollments
+has_many :teachers, through: :courses
+
+validates :name, presence: true

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -1,6 +1,6 @@
 class ViewingParty < ApplicationRecord
-  has_many :users, through: :user_viewing_parties
   has_many :user_viewing_parties
+  has_many :users, through: :user_viewing_parties
 
   validates :name, presence: true
   validates :start_time, presence: true
@@ -21,10 +21,8 @@ class ViewingParty < ApplicationRecord
     puts "Viewing party created: #{viewing_party.id}"
 
 
-    host_id = invitees.first 
-    host = User.find_by(id: host_id)
-    raise ActiveRecord::RecordInvalid.new(viewing_party), "Host user not found" if host.nil?
-    puts "Host found: #{host.id}"
+    host = find_and_validate_host!(invitees, viewing_party)
+    puts "Host found: #{host}"
     # raise ActiveRecord::RecordInvalid.new(self.new), "Host user not found" if host.nil 
 
     UserViewingParty.create!(viewing_party: viewing_party, user: host, is_host: true)
@@ -32,6 +30,7 @@ class ViewingParty < ApplicationRecord
 
     # if new_viewing_party.persisted? #successfully saved? to prevent associating users w/ non-existent viewing parties
     # end
+    host_id = host.id
     invitees.each do |invitee_id|
       next if invitee_id == host_id
       invitee = User.find_by(id: invitee_id)
@@ -52,6 +51,13 @@ class ViewingParty < ApplicationRecord
 
   def self.extract_invitees(params)
     params[:invitees].map(&:to_i) || []
+  end
+
+  def self.find_and_validate_host!(invitees, viewing_party)
+    host_id = invitees.first 
+    host = User.find_by(id: host_id)
+    raise ActiveRecord::RecordInvalid.new(viewing_party), "Host user not found" if host.nil?
+    host
   end
 
 

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -8,6 +8,34 @@ class ViewingParty < ApplicationRecord
   validates :movie_id, presence: true
   validates :movie_title, presence: true
   # validates :host_user_id, presence: true
+
+  def self.create_with_invitees!(params)
+    permitted_params = params.permit(:name, :start_time, :end_time, :movie_id, :movie_title)
+
+    invitees = params[:invitees].map(&:to_i) || []
+
+    viewing_party = ViewingParty.create!(permitted_params)
+
+    host_id = invitees.first 
+    host = User.find_by(id: host_id)
+    raise ActiveRecord::RecordInvalid.new(viewing_party), "Host user not found" if host.nil?
+    # raise ActiveRecord::RecordInvalid.new(self.new), "Host user not found" if host.nil 
+
+    UserViewingParty.create!(viewing_party: viewing_party, user: host, is_host: true)
+
+    # if new_viewing_party.persisted? #successfully saved? to prevent associating users w/ non-existent viewing parties
+    # end
+    invitees.each do |invitee_id|
+      next if invitee_id == host_id
+      invitee = User.find_by(id: invitee_id)
+      UserViewingParty.create!(viewing_party: viewing_party, user: invitee, is_host: false) if invitee
+    end
+
+    viewing_party
+
+  end
+
+
  
 end
 

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -11,10 +11,9 @@ class ViewingParty < ApplicationRecord
 
   def self.create_with_invitees!(params)
     permitted_params = permit_params(params)
-    # permitted_params = params.permit(:name, :start_time, :end_time, :movie_id, :movie_title)
     puts "Params permitted: #{permitted_params}"
 
-    invitees = params[:invitees].map(&:to_i) || []
+    invitees = extract_invitees(params)
     puts "Invitees extracted: #{invitees}"
 
 
@@ -51,6 +50,9 @@ class ViewingParty < ApplicationRecord
     params.permit(:name, :start_time, :end_time, :movie_id, :movie_title)
   end
 
+  def self.extract_invitees(params)
+    params[:invitees].map(&:to_i) || []
+  end
 
 
  

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -16,28 +16,28 @@ class ViewingParty < ApplicationRecord
     invitees = extract_invitees(params)
     puts "Invitees extracted: #{invitees}"
 
-
     viewing_party = ViewingParty.create!(permitted_params)
-    puts "Viewing party created: #{viewing_party.id}"
-
+    puts "Viewing party created: #{viewing_party}"
 
     host = find_and_validate_host!(invitees, viewing_party)
     puts "Host found: #{host}"
     # raise ActiveRecord::RecordInvalid.new(self.new), "Host user not found" if host.nil 
 
-    UserViewingParty.create!(viewing_party: viewing_party, user: host, is_host: true)
+    # UserViewingParty.create!(viewing_party: viewing_party, user: host, is_host: true)
     
-
     # if new_viewing_party.persisted? #successfully saved? to prevent associating users w/ non-existent viewing parties
     # end
-    host_id = host.id
-    invitees.each do |invitee_id|
-      next if invitee_id == host_id
-      invitee = User.find_by(id: invitee_id)
-      UserViewingParty.create!(viewing_party: viewing_party, user: invitee, is_host: false) if invitee
-    end
+    puts "Invitees before association with VP: #{invitees}"
+    associate_user_with_viewing_party(viewing_party, invitees, host)
+    # host_id = host.id
+    # invitees.each do |invitee_id|
+    #   next if invitee_id == host_id
+    #   invitee = User.find_by(id: invitee_id)
+    #   UserViewingParty.create!(viewing_party: viewing_party, user: invitee, is_host: false) if invitee
+    # end
     puts "Users associated"
-
+    puts "Invitees after association with VP: #{invitees}"
+    puts "Viewing party : #{viewing_party}" 
 
     viewing_party
 
@@ -58,6 +58,19 @@ class ViewingParty < ApplicationRecord
     host = User.find_by(id: host_id)
     raise ActiveRecord::RecordInvalid.new(viewing_party), "Host user not found" if host.nil?
     host
+  end
+
+  def self.associate_user_with_viewing_party(viewing_party, invitees, host)
+    host_id = host.id
+    invitees.each do |invitee_id|
+      # next if invitee_id == host_id?
+      invitee = User.find_by(id: invitee_id)
+      UserViewingParty.create!(viewing_party: viewing_party, user: invitee, is_host: false) if invitee
+    end
+  end
+
+  def self.create_user_viewing_party!(viewing_party, user, is_host)
+    UserViewingParty.create!(viewing_party: viewing_party, user: host, is_host: true)
   end
 
 

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -1,18 +1,18 @@
 class ViewingParty < ApplicationRecord
-  has_many :users, through: user_viewing_parties
+  has_many :users, through: :user_viewing_parties
 
   validates :name, presence: true
   validates :start_time, presence: true
   validates :end_time, presence: true
   validates :movie_id, presence: true
   validates :movie_title, presence: true
-  validates :host_user_id, presence: true
+  # validates :host_user_id, presence: true
  
 end
 
 
-has_many :enrollments
-has_many :courses, through: :enrollments
-has_many :teachers, through: :courses
+# has_many :enrollments
+# has_many :courses, through: :enrollments
+# has_many :teachers, through: :courses
 
-validates :name, presence: true
+# validates :name, presence: true

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -61,10 +61,17 @@ class ViewingParty < ApplicationRecord
   end
 
   def self.associate_user_with_viewing_party(viewing_party, invitees, host)
-    host_id = host.id
+    the_host_id = host.id
+    puts "Processing invitees: #{invitees}"
+    puts "Host ID: #{the_host_id}"  
+
+    invitees << host_id unless invitees.include?(the_host_id)
+
     invitees.each do |invitee_id|
-      # next if invitee_id == host_id?
+      # next if invitee_id == the_host_id
       invitee = User.find_by(id: invitee_id)
+      puts "Associating invitee: #{invitee_id}" if invitee
+      is_host = (invitee_id == the_host_id)
       UserViewingParty.create!(viewing_party: viewing_party, user: invitee, is_host: false) if invitee
     end
   end

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -10,12 +10,18 @@ class ViewingParty < ApplicationRecord
   # validates :host_user_id, presence: true
 
   def self.create_with_invitees!(params)
-    permitted_params = params.permit(:name, :start_time, :end_time, :movie_id, :movie_title)
+    permitted_params = permit_params(params)
+    # permitted_params = params.permit(:name, :start_time, :end_time, :movie_id, :movie_title)
+    puts "Params permitted: #{permitted_params}"
 
     invitees = params[:invitees].map(&:to_i) || []
+    puts "Invitees extracted: #{invitees}"
+
 
     viewing_party = ViewingParty.create!(permitted_params)
-   
+    puts "Viewing party created: #{viewing_party.id}"
+
+
     host_id = invitees.first 
     host = User.find_by(id: host_id)
     raise ActiveRecord::RecordInvalid.new(viewing_party), "Host user not found" if host.nil?
@@ -38,6 +44,13 @@ class ViewingParty < ApplicationRecord
     viewing_party
 
   end
+
+  private
+
+  def self.permit_params(params)
+    params.permit(:name, :start_time, :end_time, :movie_id, :movie_title)
+  end
+
 
 
  

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -15,13 +15,15 @@ class ViewingParty < ApplicationRecord
     invitees = params[:invitees].map(&:to_i) || []
 
     viewing_party = ViewingParty.create!(permitted_params)
-
+   
     host_id = invitees.first 
     host = User.find_by(id: host_id)
     raise ActiveRecord::RecordInvalid.new(viewing_party), "Host user not found" if host.nil?
+    puts "Host found: #{host.id}"
     # raise ActiveRecord::RecordInvalid.new(self.new), "Host user not found" if host.nil 
 
     UserViewingParty.create!(viewing_party: viewing_party, user: host, is_host: true)
+    
 
     # if new_viewing_party.persisted? #successfully saved? to prevent associating users w/ non-existent viewing parties
     # end
@@ -30,6 +32,8 @@ class ViewingParty < ApplicationRecord
       invitee = User.find_by(id: invitee_id)
       UserViewingParty.create!(viewing_party: viewing_party, user: invitee, is_host: false) if invitee
     end
+    puts "Users associated"
+
 
     viewing_party
 

--- a/app/serializers/viewing_party_serializer.rb
+++ b/app/serializers/viewing_party_serializer.rb
@@ -20,4 +20,27 @@ class ViewingPartySerializer
       }
     }
   end
+
+  def self.format_viewing_parties(viewing_parties)
+    { 
+    data: viewing_parties.map do |viewing_party| {
+      id: viewing_party.id.to_s,
+      type: "viewing_party",
+      attributes: {
+        name: viewing_party.name, 
+        start_time: viewing_party.start_time,
+        end_time: viewing_party.end_time,
+        movie_id: viewing_party.movie_id,
+        movie_title: viewing_party.movie_title,
+        invitees: viewing_party.user_viewing_parties.map do |uvp| {
+          id: uvp.user.id,
+          name: uvp.user.name, 
+          username: uvp.user.username
+        }
+        end
+        }
+      }
+    end
+    }
+  end
 end

--- a/app/serializers/viewing_party_serializer.rb
+++ b/app/serializers/viewing_party_serializer.rb
@@ -1,0 +1,23 @@
+class ViewingPartySerializer
+  def self.format_viewing_party(viewing_party_data)
+    { 
+    data: {
+      id: viewing_party_data.id.to_s,
+      type: "viewing_party",
+      attributes: {
+        name: viewing_party_data.name, 
+        start_time: viewing_party_data.start_time,
+        end_time: viewing_party_data.end_time,
+        movie_id: viewing_party_data.movie_id,
+        movie_title: viewing_party_data.movie_title,
+        invitees: viewing_party_data.user_viewing_parties.map do |uvp| {
+          id: uvp.user.id,
+          name: uvp.user.name, 
+          username: uvp.user.username
+        }
+        end
+        }
+      }
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,11 @@ Rails.application.routes.draw do
           get :search
         end
       end
-      resources :viewing_parties, only: [:create, :update]
+      resources :viewing_parties, only: [:create] do
+        member do
+          patch :add_user
+        end
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
           get :search
         end
       end
-      resources :viewing_parties, only: [:create] do
+      resources :viewing_parties, only: [:index, :create] do
         member do
           patch :add_user
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,9 +18,10 @@ Rails.application.routes.draw do
           get :search
         end
       end
-      # get 'movies/top_rated', to: 'movie#top_rated'
-      # get 'movies/search', to: 'movies#search'
-      
+      resources :viewing_parties, only: [:create, :update]
     end
   end
 end
+
+     # get 'movies/top_rated', to: 'movie#top_rated'
+      # get 'movies/search', to: 'movies#search'

--- a/db/migrate/20250207230603_create_viewing_parties.rb
+++ b/db/migrate/20250207230603_create_viewing_parties.rb
@@ -1,0 +1,14 @@
+class CreateViewingParties < ActiveRecord::Migration[7.1]
+  def change
+    create_table :viewing_parties do |t|
+      t.string :name
+      t.datetime :start_time
+      t.datetime :end_time
+      t.integer :movie_id
+      t.string :movie_title
+      t.integer :host_user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250207234143_create_user_viewing_parties.rb
+++ b/db/migrate/20250207234143_create_user_viewing_parties.rb
@@ -1,0 +1,10 @@
+class CreateUserViewingParties < ActiveRecord::Migration[7.1]
+  def change
+    create_table :user_viewing_parties do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :viewing_party, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250209014520_add_is_host_to_user_viewing_parties.rb
+++ b/db/migrate/20250209014520_add_is_host_to_user_viewing_parties.rb
@@ -1,0 +1,5 @@
+class AddIsHostToUserViewingParties < ActiveRecord::Migration[7.1]
+  def change
+    add_column :user_viewing_parties, :is_host, :boolean
+  end
+end

--- a/db/migrate/20250209014810_change_is_host_null_constraint_in_user_viewing_parties.rb
+++ b/db/migrate/20250209014810_change_is_host_null_constraint_in_user_viewing_parties.rb
@@ -1,0 +1,5 @@
+class ChangeIsHostNullConstraintInUserViewingParties < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :user_viewing_parties, :is_host, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_07_234143) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_09_014810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_07_234143) do
     t.bigint "viewing_party_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_host", null: false
     t.index ["user_id"], name: "index_user_viewing_parties_on_user_id"
     t.index ["viewing_party_id"], name: "index_user_viewing_parties_on_viewing_party_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_23_211921) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_07_234143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "user_viewing_parties", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "viewing_party_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_viewing_parties_on_user_id"
+    t.index ["viewing_party_id"], name: "index_user_viewing_parties_on_viewing_party_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -24,4 +33,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_211921) do
     t.index ["api_key"], name: "index_users_on_api_key", unique: true
   end
 
+  create_table "viewing_parties", force: :cascade do |t|
+    t.string "name"
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.integer "movie_id"
+    t.string "movie_title"
+    t.integer "host_user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "user_viewing_parties", "users"
+  add_foreign_key "user_viewing_parties", "viewing_parties"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,3 +10,4 @@
 User.create!(name: "Danny DeVito", username: "danny_de_v", password: "jerseyMikesRox7")
 User.create!(name: "Dolly Parton", username: "dollyP", password: "Jolene123")
 User.create!(name: "Lionel Messi", username: "futbol_geek", password: "test123")
+User.create!(name: "C.J. Cregg", username: "chief_O_staff", password: "sorkin1")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,3 +11,4 @@ User.create!(name: "Danny DeVito", username: "danny_de_v", password: "jerseyMike
 User.create!(name: "Dolly Parton", username: "dollyP", password: "Jolene123")
 User.create!(name: "Lionel Messi", username: "futbol_geek", password: "test123")
 User.create!(name: "C.J. Cregg", username: "chief_O_staff", password: "sorkin1")
+User.create!(name: "Moira Rose", username: "lots_of_wigs", password: "rose1")

--- a/spec/models/scratch_paper.rb
+++ b/spec/models/scratch_paper.rb
@@ -1,0 +1,131 @@
+#user_viewing_party
+class UserViewingParty < ApplicationRecord
+  # validates :user, presence: true
+  # validates :viewing_party, presence: true 
+  belongs_to :user
+  belongs_to :viewing_party
+
+  validates :user, presence: true
+end
+
+
+#viewing_party controller
+class Api::V1::ViewingPartiesController < ApplicationController
+
+  def create
+     new_viewing_party = ViewingParty.create_with_invitees!(params)
+     
+      render json: ViewingPartySerializer.format_viewing_party(new_viewing_party), status: :created
+      
+  rescue ActiveRecord::RecordInvalid => e 
+    render json: { 
+      status: "error", 
+      message: e.record.errors.full_messages
+    }, status: :unprocessable_entity
+  
+  end
+end
+
+
+
+
+#viewing_party model
+class ViewingParty < ApplicationRecord
+  has_many :users, through: :user_viewing_parties
+  has_many :user_viewing_parties
+
+  validates :name, presence: true
+  validates :start_time, presence: true
+  validates :end_time, presence: true
+  validates :movie_id, presence: true
+  validates :movie_title, presence: true
+  # validates :host_user_id, presence: true
+
+  def self.create_with_invitees!(params)
+    permitted_params = permit_params(params)
+   
+    invitees = self.extract_invitees(params)
+ 
+    viewing_party = create_viewing_party!(permitted_params)
+ 
+    host = find_and_validate_host!(invitees, viewing_party)
+    
+    associate_user_with_viewing_party(viewing_party, invitees, host)
+   
+    viewing_party
+  end
+
+  private
+
+  def self.permit_params(params)
+    params.permit(:name, :start_time, :end_time, :movie_id, :movie_title, invitees: [])
+  end
+
+  def self.extract_invitees(params)
+    # invitees = params[:invitees].map(&:to_i) || []
+    invitees = (params[:invitees] || []).map(&:to_i)
+  end
+
+  def self.create_viewing_party!(permitted_params)
+    ViewingParty.create!(permitted_params)
+  end
+
+  def self.find_and_validate_host!(invitees, viewing_party)
+    host_id = invitees.first 
+    host = User.find_by(id: host_id)
+    raise ActiveRecord::RecordInvalid.new(viewing_party), "Host user not found" if host.nil?
+  end
+
+  def self.associate_user_with_viewing_party(viewing_party, invitees, host)
+    host_id = invitees.first 
+    create_user_viewing_party(viewing_party, host, true)
+    invitees.each do |invitee_id|
+      next if invitee_id == host_id
+      invitee = User.find_by(id: invitee_id)
+      create_user_viewing_party(viewing_party, invitee, false) if invitee
+    end
+  end
+
+  def self.create_user_viewing_party(viewing_party, user, is_host)
+    UserViewingParty.create!(
+      viewing_party: viewing_party,
+      user: user, 
+      is_host: is_host
+    ) 
+  end
+ 
+end
+
+
+
+#viewing_parties_request_spec
+require "rails_helper"
+
+RSpec.describe "Viewing Party API", type: :request do
+  before(:each) do
+    @user = User.create!(id: 1, name: "John Doe", username: "johndoe", password: "password")
+    # @user2 = User.create!(id: 2, name: "John Doe2", username: "johndoe2", password: "password2")
+  end
+  
+  it "creates a viewing party" do
+    viewing_party_params = {
+      "name": "CJ's partay", 
+      "start_time": "2025-02-01 10:00:00", 
+      "end_time": "2025-02-01 14:30:00", 
+      "movie_id": 278,
+      "movie_title": "The Shawshank Redemption",
+      "invitees": ["11", "7", "5"]
+    }
+    post "/api/v1/viewing_parties", params: viewing_party_params 
+    
+    expect(response).to have_http_status(:created) 
+    
+    json = JSON.parse(response.body, symbolize_names: true)
+  
+    expect(json[:data][:id]).to be_a(String)
+    expect(json[:data][:type]).to eq("viewing_party")
+    expect(json[:data][:attributes][:name]).to eq("CJ's partay")
+    expect(json[:data][:attributes][:movie_id]).to eq(278)
+    expect(json[:data][:attributes][:invitees][0][:id]).to eq(11)
+  end
+end 

--- a/spec/models/user_viewing_party.rb
+++ b/spec/models/user_viewing_party.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe ViewingParty, type: :model do
+  # describe "validations" do
+  #   it { should validate_presence_of(:user_id) }
+  #   it { should validate_presence_of(:viewing_party_id) }
+  # end
+
+  describe "relationships" do
+    it { should belong_to :user}
+    it { should belong_to :viewing_party}
+  end
+
+  describe "model methods" do
+    before :each do
+      test_data
+    end  
+
+  end

--- a/spec/models/viewing_party_spec.rb
+++ b/spec/models/viewing_party_spec.rb
@@ -7,10 +7,46 @@ RSpec.describe ViewingParty, type: :model do
     it { should validate_presence_of(:end_time) }
     it { should validate_presence_of(:movie_id) }
     it { should validate_presence_of(:movie_title) }
-    # it { should validate_presence_of(:host_user_id) }
   end
 
   describe "relationships" do
     it { should have_many(:users).through(:user_viewing_parties)}
+    it { should have_many(:user_viewing_parties)}
   end
+  
+  describe "specific attribute validations" do
+     
+    it "is valid when all attributes are present and valid" do
+
+      # @user1 = User.create!(id: 11, name: "Barbara", username: "leo_fan", password: "password")
+      # @user2 = User.create!(id: 7, name: "Ceci", username: "titanic_forever", password: "password")
+      # @user3 = User.create!(id: 5, name: "Peyton", username: "star_wars_geek_8", password: "password") 
+
+      @vp1 = ViewingParty.create!("name": "CJ's partay", "start_time": "2025-02-01 10:00:00", "end_time": "2025-02-01 14:30:00", "movie_id": 278, "movie_title": "The Shawshank Redemption")    
+
+      expect(@vp1 ).to be_valid
+      expect(@vp1 .persisted?).to be true
+    end
+  end
+
+  describe "Instance methods" do
+    describe '.create_with_invitees!' do
+      xit 'creates a viewing party with valid attributes and invitees' do
+
+        @vp1 = ViewingParty.create!("name": "CJ's partay", "start_time": "2025-02-01 10:00:00", "end_time": "2025-02-01 14:30:00", "movie_id": 278, "movie_title": "The Shawshank Redemption")    
+
+
+        expect(@vp1).to be_persisted
+        expect(@vp1.users).to include(@user1, @user2, @user3)
+        # expect(viewing_party.user_viewing_parties.find_by(user: @user1).is_host).to be true
+      end
+
+      # xit 'raises an error if the host is not found' do
+      #   #test assertions
+      # end
+    end
+  end
+
+
+
 end

--- a/spec/models/viewing_party_spec.rb
+++ b/spec/models/viewing_party_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe ViewingParty, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:start_time) }
+    it { should validate_presence_of(:end_time) }
+    it { should validate_presence_of(:movie_id) }
+    it { should validate_presence_of(:movie_title) }
+    it { should validate_presence_of(:host_user_id) }
+  end
+
+  describe "relationships" do
+    it { should have_many(:users).through(:user_viewing_parties)}
+  end
+end

--- a/spec/models/viewing_party_spec.rb
+++ b/spec/models/viewing_party_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ViewingParty, type: :model do
     it { should validate_presence_of(:end_time) }
     it { should validate_presence_of(:movie_id) }
     it { should validate_presence_of(:movie_title) }
-    it { should validate_presence_of(:host_user_id) }
+    # it { should validate_presence_of(:host_user_id) }
   end
 
   describe "relationships" do

--- a/spec/requests/api/v1/movies_request_spec.rb
+++ b/spec/requests/api/v1/movies_request_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "Movies Endpoints" do
 
         expect(response).to be_successful
         json = JSON.parse(response.body, symbolize_names: true)
-
    
         expect(json[:data][0][:id]).to be_a(String)
         expect(json[:data][0][:type]).to eq("movie")

--- a/spec/requests/api/v1/viewing_parties_request_spec.rb
+++ b/spec/requests/api/v1/viewing_parties_request_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "Viewing Party API", type: :request do
     expect(json[:data][:type]).to eq("viewing_party")
     expect(json[:data][:attributes][:name]).to eq("CJ's partay")
     expect(json[:data][:attributes][:movie_id]).to eq(278)
-    # binding.pry
     expect(json[:data][:attributes][:invitees][0][:id]).to eq(11)
   end
 end 

--- a/spec/requests/api/v1/viewing_parties_request_spec.rb
+++ b/spec/requests/api/v1/viewing_parties_request_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Viewing Party API", type: :request do
   before(:each) do
     # DatabaseCleaner.clean_with(:truncation)  # Make sure we start clean
     @user = User.create!(id: 1, name: "John Doe", username: "johndoe", password: "password")
+    @user2 = User.create!(id: 15, name: "John Doe15", username: "johndoe15", password: "password15")
   end
   
   it "creates a viewing party" do
@@ -28,4 +29,27 @@ RSpec.describe "Viewing Party API", type: :request do
     expect(json[:data][:attributes][:movie_id]).to eq(278)
     expect(json[:data][:attributes][:invitees][0][:id]).to eq(11)
   end
+
+  it "adds another user to an existing a viewing party" do
+    viewing_party = ViewingParty.create!(
+      name: "Alexis's partay",
+      start_time: '2025-03-01 18:00:00',
+      end_time: '2025-03-01 23:30:00',
+      movie_id: 278,
+      movie_title: 'The Shawshank Redemption'
+    )
+
+    viewing_party_params = { invitees_user_id: @user2.id }
+
+    patch "/api/v1/viewing_parties/#{viewing_party.id}/add_user", params: viewing_party_params 
+    
+    expect(response).to have_http_status(:ok) 
+    
+    json = JSON.parse(response.body, symbolize_names: true)
+    expect(json[:message]).to eq('User added successfully')
+  end
+
+
+  
+
 end 

--- a/spec/requests/api/v1/viewing_parties_request_spec.rb
+++ b/spec/requests/api/v1/viewing_parties_request_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Viewing Party API", type: :request do
+  before(:each) do
+    @user = User.create!(id: 1, name: "John Doe", username: "johndoe", password: "password")
+  end
+  
+  it "creates a viewing party" do
+    viewing_party_params = {
+      "name": "CJ's partay", 
+      "start_time": "2025-02-01 10:00:00", 
+      "end_time": "2025-02-01 14:30:00", 
+      "movie_id": 278,
+      "movie_title": "The Shawshank Redemption",
+      "invitees": ["11", "7", "5"]
+    }
+    
+    post "/api/v1/viewing_parties", params: viewing_party_params 
+    
+    expect(response).to have_http_status(:created) 
+    
+    json = JSON.parse(response.body, symbolize_names: true)
+  
+    expect(json[:data][:id]).to be_a(String)
+    expect(json[:data][:type]).to eq("viewing_party")
+    expect(json[:data][:attributes][:name]).to eq("CJ's partay")
+    expect(json[:data][:attributes][:movie_id]).to eq(278)
+    expect(json[:data][:attributes][:invitees][0][:id]).to eq(11)
+  end
+end 

--- a/spec/requests/api/v1/viewing_parties_request_spec.rb
+++ b/spec/requests/api/v1/viewing_parties_request_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Viewing Party API", type: :request do
     expect(json[:data][:type]).to eq("viewing_party")
     expect(json[:data][:attributes][:name]).to eq("CJ's partay")
     expect(json[:data][:attributes][:movie_id]).to eq(278)
+    # binding.pry
     expect(json[:data][:attributes][:invitees][0][:id]).to eq(11)
   end
 end 

--- a/spec/requests/api/v1/viewing_parties_request_spec.rb
+++ b/spec/requests/api/v1/viewing_parties_request_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Viewing Party API", type: :request do
   before(:each) do
+    # DatabaseCleaner.clean_with(:truncation)  # Make sure we start clean
     @user = User.create!(id: 1, name: "John Doe", username: "johndoe", password: "password")
   end
   

--- a/spec/requests/api/v1/viewing_parties_request_spec.rb
+++ b/spec/requests/api/v1/viewing_parties_request_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Viewing Party API", type: :request do
   before(:each) do
+    User.destroy_all
+    ViewingParty.destroy_all
     # DatabaseCleaner.clean_with(:truncation)  # Make sure we start clean
     @user = User.create!(id: 1, name: "John Doe", username: "johndoe", password: "password")
     @user2 = User.create!(id: 15, name: "John Doe15", username: "johndoe15", password: "password15")
@@ -14,10 +16,12 @@ RSpec.describe "Viewing Party API", type: :request do
       "end_time": "2025-02-01 14:30:00", 
       "movie_id": 278,
       "movie_title": "The Shawshank Redemption",
-      "invitees": ["11", "7", "5"]
+      "invitees": ["15", "7", "5"]
     }
     
     post "/api/v1/viewing_parties", params: viewing_party_params 
+
+    # binding.pry
     
     expect(response).to have_http_status(:created) 
     
@@ -27,7 +31,7 @@ RSpec.describe "Viewing Party API", type: :request do
     expect(json[:data][:type]).to eq("viewing_party")
     expect(json[:data][:attributes][:name]).to eq("CJ's partay")
     expect(json[:data][:attributes][:movie_id]).to eq(278)
-    expect(json[:data][:attributes][:invitees][0][:id]).to eq(11)
+    expect(json[:data][:attributes][:invitees][0][:id]).to eq(15)
   end
 
   it "adds another user to an existing a viewing party" do
@@ -47,6 +51,36 @@ RSpec.describe "Viewing Party API", type: :request do
     
     json = JSON.parse(response.body, symbolize_names: true)
     expect(json[:message]).to eq('User added successfully')
+  end
+
+  it "retrieves all viewing parties" do
+    viewing_party = ViewingParty.create!(
+      name: "Alexis's partay",
+      start_time: '2025-03-01 18:00:00',
+      end_time: '2025-03-01 23:30:00',
+      movie_id: 278,
+      movie_title: 'The Shawshank Redemption'
+    )
+
+    ViewingParty.create!(
+      name: "Party 2",
+      start_time: '2025-02-11 19:00:00',
+      end_time: '2025-02-11 22:00:00',
+      movie_id: 102,
+      movie_title: 'Movie 2'
+    )
+
+    get "/api/v1/viewing_parties"  
+    
+    expect(response).to have_http_status(:ok) 
+    
+    json = JSON.parse(response.body, symbolize_names: true)
+    
+    expect(json[:data]).to be_an(Array)
+    expect(json[:data].size).to eq(2)
+
+    expect(json[:data][0][:attributes][:name]).to eq("Alexis's partay")
+    expect(json[:data][1][:attributes][:name]).to eq("Party 2")
   end
 
 


### PR DESCRIPTION
Implement Viewing Party Endpoints
**Overview**
This pull request introduces the following features for managing viewing parties:
	
**1.	Create Viewing Party Endpoint**
	▪	Route: ⁠POST /api/v1/viewing_parties
	▪	Functionality: Allows users to create a new viewing party with specified details and invitees.
	▪	Serializer: Utilizes ⁠ViewingPartySerializer to format the response.
	▪	Tests: Includes request specs to validate successful creation and response structure.
**2.	Add User to Viewing Party Endpoint**
	▪	Route: ⁠PATCH /api/v1/viewing_parties/:id/add_user
	▪	Functionality: Enables adding an existing user to a specified viewing party.
	▪	Error Handling: Handles cases where the user is not found or cannot be added.
	▪	Tests: Includes request specs to ensure proper user addition and error responses.
**3.	Index Action for Viewing Parties**
	▪	Route: ⁠GET /api/v1/viewing_parties
	▪	Functionality: Retrieves a list of all viewing parties.
	▪	Serializer: Formats multiple viewing parties using ⁠ViewingPartySerializer.
	▪	Tests: Includes request specs to verify the retrieval and formatting of viewing party data.
**Additional Components**
	•	**Join Table:** ⁠UserViewingParty join table created to manage the many-to-many relationship between users and viewing parties, including an ⁠is_host attribute to differentiate hosts from invitees.
	•	Model: ⁠ViewingParty model created with associations to users through ⁠user_viewing_parties.
	•	Serializers: Updated ⁠ViewingPartySerializer to handle both single and multiple viewing party responses.